### PR TITLE
Prevent `unbound variable` error when running rust commands without arguments

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
-set -efuo pipefail
 export CARGO_HOME=$ASDF_INSTALL_PATH
 export RUSTUP_HOME=$ASDF_INSTALL_PATH

--- a/bin/install
+++ b/bin/install
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -efuo pipefail
 
 script_dir=$(dirname "${BASH_SOURCE[0]}")
 # shellcheck source=/dev/null


### PR DESCRIPTION
Fixes https://github.com/code-lever/asdf-rust/issues/17

Removing only the `u` option from `set` would avoid this specific issue, however I believe all these options have the potential to create incompatibilities if the asdf scripts aren't written for them.