### PR TITLE
fix: install with default creates

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -15,8 +15,8 @@ install_default_cargo_crates() {
   if [ ! -f $default_cargo_crates ]; then return; fi
 
   cat "$default_cargo_crates" | while read -r line; do
-    name=$(echo "$line" | \
-      sed 's|\(.*\) //.*$|\1|' | \ # handle comments after crate name
+    name=$(echo "$line" | 
+      sed 's|\(.*\) //.*$|\1|' |  # handle comments after crate name
       sed -E 's|^[[:space:]]*//.*||') # handle full line comments
 
     if [ -z $name ]; then continue ; fi


### PR DESCRIPTION
## Description
I got an issue when I installed rust with default cargo crates. So I investigated to get this fix. 

## Error
``` bash
To configure your current shell run                                                                                                                                                            
source $HOME.asdf/installs/rust/1.45.0/env                                                                                                                                           
$HOME/.asdf/plugins/rust/bin/install: line 20:  #: command not found                                                                                                                  
$HOMEl/.asdf/plugins/rust/bin/install: line 22: [: too many arguments                                                                                                                  
                                                                                                                                                                                               
Installing ripgrep   
```
## Analysis
The comment was interpreted.