### PR TITLE
Allow custom location for default crates file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ ripgrep
 // install from source
 --git https://github.com/sharkdp/bat
 ```
+
+You can specify a non-default location of this file by setting a `ASDF_CRATE_DEFAULT_PACKAGES_FILE` variable.

--- a/bin/install
+++ b/bin/install
@@ -10,7 +10,7 @@ install_rust() {
 }
 
 install_default_cargo_crates() {
-  local default_cargo_crates="${HOME}/.default-cargo-crates"
+  local default_cargo_crates="${ASDF_CRATE_DEFAULT_PACKAGES_FILE:=$HOME}/.default-cargo-crates"
 
   if [ ! -f $default_cargo_crates ]; then return; fi
 


### PR DESCRIPTION
So this PR is inspired by https://github.com/asdf-vm/asdf-ruby/pull/212/ which adds the ability to customize the default packages file location. 

Let me know if you have any feedback or thoughts!