### PR TITLE
Allow to install specific profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ ripgrep
 ```
 
 You can specify a non-default location of this file by setting a `ASDF_CRATE_DEFAULT_PACKAGES_FILE` variable.
+
+`ASDF_RUST_PROFILE` variable can be used to install different from `default` profile (e.g. minimal or complete).

--- a/bin/install
+++ b/bin/install
@@ -6,7 +6,7 @@ script_dir=$(dirname "${BASH_SOURCE[0]}")
 
 install_rust() {
     curl --fail --silent --show-error https://sh.rustup.rs \
-    | sh -s -- -y --no-modify-path --default-toolchain "$ASDF_INSTALL_VERSION"
+    | sh -s -- -y --no-modify-path --default-toolchain "$ASDF_INSTALL_VERSION" --profile "${ASDF_RUST_PROFILE:-default}"
 }
 
 install_default_cargo_crates() {


### PR DESCRIPTION
This PR adds ability to pass value to `--profile` option with `ASDF_RUST_PROFILE` environmental variable. If not set, defaults to `default`.