### PR TITLE
Adding option to not install docs on the disk

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -6,7 +6,7 @@ script_dir=$(dirname "${BASH_SOURCE[0]}")
 
 install_rust() {
     curl --fail --silent --show-error https://sh.rustup.rs \
-    | sh -s -- -y --no-modify-path --default-toolchain "$ASDF_INSTALL_VERSION"
+    | sh -s -- -y --no-modify-path --profile minimal --default-toolchain "$ASDF_INSTALL_VERSION"
 }
 
 install_default_cargo_crates() {


### PR DESCRIPTION
Based on [this](https://github.com/rust-lang/rustup/issues/998#issuecomment-542332509), we can make installation of rust docs on disk optional to save size of the install on disk.