### PR TITLE
fix: support also older Rust releases, list-all fetches from page1+2

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-releases_path=https://api.github.com/repos/rust-lang/rust/tags
+releases_path=https://api.github.com/repos/rust-lang/rust/tags?page=
 
 cmd="curl -s"
 
@@ -9,8 +9,13 @@ if [ -n "$GITHUB_API_TOKEN" ]; then
  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
 fi
 
-cmd="$cmd $releases_path"
+
+idx=1
+cmd1="$cmd $releases_path$idx"
+idx=2
+cmd2="$cmd $releases_path$idx"
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | sed -n 's/.*"name": "\([0-9\.]*\)",/\1/p' | sed -n '1!G;h;$p')
-echo nightly beta stable $versions
+versions=$(eval $cmd1 | sed -n 's/.*"name": "\([0-9\.]*\)",/\1/p' | sed -n '1!G;h;$p')
+versions2=$(eval $cmd2 | sed -n 's/.*"name": "\([0-9\.]*\)",/\1/p' | sed -n '1!G;h;$p')
+echo nightly beta stable $versions $versions2 


### PR DESCRIPTION
The GitHub api only gives 30 items per page to limit requests sizes. This will leave all older Rust releases in the dust.

Added another curl call to fetch page 2 to get older versions that are still relevant.
